### PR TITLE
fix(time-observer): fix crash when time observer queue is empty

### DIFF
--- a/framework/Source/iOS/MoviePlayer.swift
+++ b/framework/Source/iOS/MoviePlayer.swift
@@ -388,7 +388,7 @@ private extension MoviePlayer {
     
     func _notifyTimeObserver(with sampleTime: CMTime) {
         let currentTime = CMTimeGetSeconds(sampleTime)
-        while let lastObserver = timeObserversQueue.last, lastObserver.targetTime <= currentTime {
+        while !timeObserversQueue.isEmpty, let lastObserver = timeObserversQueue.last, lastObserver.targetTime <= currentTime {
             timeObserversQueue.removeLast()
             DispatchQueue.main.async {
                 lastObserver.callback(currentTime)


### PR DESCRIPTION
timeObserversQueue是空的，去取last时导致的崩溃